### PR TITLE
Maxwell V3

### DIFF
--- a/buch/papers/maxwell/elektrodynamik.tex
+++ b/buch/papers/maxwell/elektrodynamik.tex
@@ -241,7 +241,7 @@ w_{\text{m}}
 \]
 
 \subsubsection{4er Stromdichte}
-Damit wir nun auch die Kopplungsterme mit dem elektromagnetischen 4er Potential ausdrücken können führen wir die 4er Stromdichte
+Damit wir nun auch die Kopplungsterme mit dem elektromagnetischen 4er Potential ausdrücken können, führen wir die 4er Stromdichte
 \(
 J:\mathbb{R}^4 \rightarrow \mathbb{R}^4
 \)
@@ -361,5 +361,11 @@ Für $i=1,2,3$ resultiert das partielle Differentialgleichungssystem
 \label{maxwell:section:ampere_dynamisch}
 \end{align}
 was dem dynamischen ampereschen Gesetz entspricht.
+
+\subsubsection{Interpretation der Resultate}
+Wir kommen nun zur Erkenntnis, dass man die fundamentalen Gleichungen des Elektromagnetismus mit einem Variationsprinzip herleiten kann.
+Eine wunderschöne Tatsache, denn einmal mehr wurden wir Zeuge davon, dass wenn wir Energien minimieren Naturgesetze resultieren!
+
+
 
 

--- a/buch/papers/maxwell/elektrodynamik.tex
+++ b/buch/papers/maxwell/elektrodynamik.tex
@@ -9,7 +9,7 @@
 %Elektrodynmaik
 \section{Elektrodynamik\label{section:maxwell:elektrodynmaik}}
 \rhead{Elektrodynamik}
-In der Elektrodynamik erlauben wirs, dass
+In der Elektrodynamik erlauben wir, dass
 \[
 \frac{\partial f}{\partial t}
 \neq

--- a/buch/papers/maxwell/elektrodynamik.tex
+++ b/buch/papers/maxwell/elektrodynamik.tex
@@ -468,9 +468,9 @@ Diese partielle Differentialgleichungen sagen uns, dass eine zeitliche Veränder
 		\def\xOffset{{(\nNodes-2)*pi/2}}
 		\def\yOffset{\A*1.1}
 		\def\zOffset{\A*1.1}
-		\draw[axis,very thick,vcol] (\xOffset,\yOffset,-\zOffset) -- ++(\A*0.6,0,0) node[right,align=center] {$\vb{v}$}; %\\propagation
-		\draw[axis,very thick,Ecol]  (\xOffset,\yOffset,-\zOffset) -- ++(0,\A*0.6,0) node[right] {$\vb{E}$};
-		\draw[axis,very thick,Bcol]   (\xOffset,\yOffset,-\zOffset) -- ++(0,0,\A*0.6) node[left] {$\vb{B}$};
+		\draw[axis,very thick,vcol] (\xOffset,\yOffset,-\zOffset) -- ++(\A*0.6,0,0) node[right,align=center] {$\vec{v}$}; %\\propagation
+		\draw[axis,very thick,Ecol]  (\xOffset,\yOffset,-\zOffset) -- ++(0,\A*0.6,0) node[right] {$\vec{E}$};
+		\draw[axis,very thick,Bcol]   (\xOffset,\yOffset,-\zOffset) -- ++(0,0,\A*0.6) node[left] {$\vec{B}$};
 		
 		% draw (anti-)nodes
 		\foreach \iNode [evaluate={\iOffset=\iNode-1;}] in {1,...,\nNodes}{

--- a/buch/papers/maxwell/elektrodynamik.tex
+++ b/buch/papers/maxwell/elektrodynamik.tex
@@ -392,7 +392,7 @@ Wenn wir in Gleichung \eqref{maxwell:section:definition_dynamisch_magnetischesFe
 =
 \nabla \cdot (\nabla \times \vec{A}).
 \]
-Da die Divergenz eines Rotationsfeldes immer null ist folgt direkt, dass
+Da die Divergenz eines Rotationsfeldes immer null ist, folgt direkt, dass
 \begin{equation}
 \nabla \cdot \vec{B}
 =
@@ -419,7 +419,7 @@ Da die partielle Ableitung nach der Zeit eine lineare Operation ist, können wir
 - \frac{\partial \vec{B}}{\partial t}.
 \end{equation}
 Was wir erhalten ist das faradaysche Gesetz der Induktion.
-Diese partielle Differentialgleichungen sagen uns, dass eine zeitliche Veränderung des magnetischen Feldes eine Rotation des elektrischen Feldes verursacht. Also sehen wir, dass auch das elektrische Feld vom magnetischen Feld beeinflusst werden kann. Da sich in der Elektrodynamik eine zeitliche Veränderung in einem Feld eine Rotation im anderen Feld zur Folge hat, ist die Existenz von elektromagnetischen Wellen auch intuitiv erklärbar. 
+Diese partielle Differentialgleichungen sagen uns, dass eine zeitliche Veränderung des magnetischen Feldes eine Rotation des elektrischen Feldes verursacht. Also sehen wir, dass auch das elektrische Feld vom magnetischen Feld beeinflusst werden kann. Da in der Elektrodynamik eine zeitliche Veränderung in einem Feld eine Rotation im anderen Feld zur Folge hat, ist die Existenz von elektromagnetischen Wellen auch intuitiv erklärbar. 
 
 
 \subsubsection{Exkurs zu elektromagnetischen Wellen}

--- a/buch/papers/maxwell/elektrodynamik.tex
+++ b/buch/papers/maxwell/elektrodynamik.tex
@@ -361,10 +361,17 @@ Für $i=1,2,3$ resultiert das partielle Differentialgleichungssystem
 \label{maxwell:section:ampere_dynamisch}
 \end{align}
 was dem dynamischen ampereschen Gesetz entspricht.
+ 
+Wir kommen nun zur Erkenntnis, dass man die fundamentalen Feldgleichungen des Elektromagnetismus mit einem Variationsprinzip herleiten kann.
+Dafür mussten wir nur die Feldenergie und Wechselwirkungen mit einem Funktional ausdrücken und dieses mithilfe der Variationsrechnung minimieren.
+Eine wunderschöne Tatsache, denn einmal mehr wurden wir Zeuge davon, dass wenn wir Energien minimieren Naturgesetze resultieren!
 
 \subsubsection{Interpretation der Resultate}
-Wir kommen nun zur Erkenntnis, dass man die fundamentalen Gleichungen des Elektromagnetismus mit einem Variationsprinzip herleiten kann.
-Eine wunderschöne Tatsache, denn einmal mehr wurden wir Zeuge davon, dass wenn wir Energien minimieren Naturgesetze resultieren!
+Was können wir aus diesen zwei partiellen Differentialgleichungen entnehmen?
+In der Gleichung \eqref{maxwell:section:gauss_dynamisch} sehen wir, dass das gausssche Gesetz im statischen wie auch im dynamischen Fall von der gleichen Form ist.
+Das heisst die Quelle des elektrischen Feldes ist eine Ladungsdichte $\varrho$.
+In der Gleichung \eqref{maxwell:section:ampere_dynamisch} fällt auf, dass das dynamische ampersche Gesetz, im Vergleich zum statischen, einen zusätzlichen Term erhalten hat, der eine zeitliche Veränderung des elektrischen Feldes beinhaltet.
+Also verursacht nicht nur eine Stromdichte, sondern auch eine zeitliche Veränderung im elektrischen Feld eine Rotation im magnetischen Feld. An dieser Stelle bemerken wir zum ersten Mal, dass das magnetische Feld vom elektrischen Feld beeinflusst werden kann.
 
 
 

--- a/buch/papers/maxwell/elektrodynamik.tex
+++ b/buch/papers/maxwell/elektrodynamik.tex
@@ -9,7 +9,7 @@
 %Elektrodynmaik
 \section{Elektrodynamik\label{section:maxwell:elektrodynmaik}}
 \rhead{Elektrodynamik}
-In der Elektrodynamik erlauben wir es, dass
+In der Elektrodynamik erlauben wirs, dass
 \[
 \frac{\partial f}{\partial t}
 \neq
@@ -51,6 +51,54 @@ Damit wir uns später ein wenig Schreibaufwand sparen können, schreiben wir die
 \partial^{\mu}.
 \]
 
+\subsubsection{4er Gradient}
+Der 4er Gradient einer Funktion $f: \mathbb{R}^4 \rightarrow \mathbb{R}$ im Raum $\Omega$ ist von der Form
+\[
+\renewcommand{\arraystretch}{1.9}
+\nabla^\mu f
+=
+\begin{pmatrix}
+	\displaystyle
+	\partial^0 f\\
+	\displaystyle
+	\partial^1 f\\
+	\displaystyle
+	\partial^2 f\\
+	\displaystyle
+	\partial^3 f
+\end{pmatrix}
+=
+\begin{pmatrix}
+	\displaystyle
+	\frac{\partial f}{\partial (ct)}\\
+	\displaystyle
+	\frac{\partial f}{\partial x}\\
+	\displaystyle
+	\frac{\partial f}{\partial y}\\
+	\displaystyle
+	\frac{\partial f}{\partial z}
+\end{pmatrix}
+=
+\begin{pmatrix}
+	\displaystyle
+	\frac{1}{c}\frac{\partial f}{\partial t}\\
+	\displaystyle
+	\frac{\partial f}{\partial x}\\
+	\displaystyle
+	\frac{\partial f}{\partial y}\\
+	\displaystyle
+	\frac{\partial f}{\partial z}
+\end{pmatrix}
+=
+\begin{pmatrix}
+	\displaystyle
+	\frac{1}{c}\frac{\partial f}{\partial t}\\
+	\displaystyle
+	\nabla f
+\end{pmatrix}.
+\]
+
+
 \subsubsection{Elektrisches Feld dynamisch}
 Das elektrische Feld
 \(
@@ -88,7 +136,7 @@ In diesem Raum existieren nun das elektrische Feld $\vec{E}(t,x,y,z)$, das magne
 Wir wählen einen ähnlichen Ansatz wie bislang, nämlich ein Integral über die Zeit der Energie im Raum zu minimieren.
 Das Integral über die Zeit ist notwendig, da wir über alle Inputgrössen integrieren müssen.
 Diese neue Grösse werden wir mit $D$ bezeichnen.
-Durch superponierung unserer bisher gefundenen Energien erhalten wir
+Durch Superponierung unserer bisher gefundenen Energien erhalten wir
 \begin{align*}
 	D
 	&=
@@ -177,7 +225,7 @@ und
 	B_z
 \end{pmatrix}.
 \end{equation}
-Daraus Ergibt sich für die Feldenergiedichten
+Daraus ergibt sich für die Feldenergiedichten
 \[
 w_{\text{e}}
 =
@@ -225,7 +273,7 @@ Uns ist es nun gelungen die Grösse $D$ mit einer Funktion und ihren partiellen 
 D
 =
 \int_{\Omega}
-\frac{1}{2\mu_0}\biggl(\left(\partial^0 A^1 + \partial^1 A^0\right)^2 + \left(\partial^0 A^2 + \partial^2 A^0\right)^2 + 
+\frac{1}{2\mu_0}\,\biggl(\left(\partial^0 A^1 + \partial^1 A^0\right)^2 + \left(\partial^0 A^2 + \partial^2 A^0\right)^2 + 
 \left(\partial^0 A^3 + \partial^3 A^0\right)^2\biggr) \\
 -  \frac{1}{2\mu_0}\,\biggl(\left(\partial^2 A^3 - \partial^3 A^2\right)^2 + \left(\partial^3 A^1 - \partial^1 A^3\right)^2 + 
 \left(\partial^1 A^2 - \partial^2 A^1\right)^2\biggr)\\
@@ -235,7 +283,7 @@ und somit die Lagrange-Funktion
 \begin{align*}
 L(\Omega^0,...,\Omega^3, A^0,...,A^3, \partial^0 A^i,...,\partial^3 A^i)
 =
-\frac{1}{2\mu_0}\biggl(\left(\partial^0 A^1 + \partial^1 A^0\right)^2 + \left(\partial^0 A^2 + \partial^2 A^0\right)^2 + 
+\frac{1}{2\mu_0}\,\biggl(\left(\partial^0 A^1 + \partial^1 A^0\right)^2 + \left(\partial^0 A^2 + \partial^2 A^0\right)^2 + 
 \left(\partial^0 A^3 + \partial^3 A^0\right)^2\biggr) \\
 -  \frac{1}{2\mu_0}\,\biggl(\left(\partial^2 A^3 - \partial^3 A^2\right)^2 + \left(\partial^3 A^1 - \partial^1 A^3\right)^2 + 
 \left(\partial^1 A^2 - \partial^2 A^1\right)^2\biggr)\\
@@ -255,7 +303,7 @@ Da unsere Lagrange-Funktion von einer Vektorgrösse abhängig ist erhalten wir e
 
 {\larger\textcircled{\smaller[2]1}} $i = 0$
 \[
-J^0  -\frac{1}{\mu_0}\biggl(\partial^1\underbrace{\left(\partial^0 A^1 + \partial^1 A^0\right)}_{\displaystyle=-E_x/c}
+J^0  -\frac{1}{\mu_0}\,\biggl(\partial^1\underbrace{\left(\partial^0 A^1 + \partial^1 A^0\right)}_{\displaystyle=-E_x/c}
 + \partial^2\underbrace{\left(\partial^0 A^2 + \partial^2 A^0\right)}_{\displaystyle=-E_y/c}
 + \partial^3\underbrace{\left(\partial^0 A^3 + \partial^3 A^0\right)}_{\displaystyle=-E_z/c}\biggr)
 =
@@ -264,7 +312,7 @@ J^0  -\frac{1}{\mu_0}\biggl(\partial^1\underbrace{\left(\partial^0 A^1 + \partia
 
 {\larger\textcircled{\smaller[2]2}} $i = 1$
 \[
-J^1  -\frac{1}{\mu_0}\biggl(\partial^0\underbrace{\left(\partial^0 A^1 + \partial^1 A^0\right)}_{\displaystyle=-E_x/c}
+J^1  -\frac{1}{\mu_0}\,\biggl(\partial^0\underbrace{\left(\partial^0 A^1 + \partial^1 A^0\right)}_{\displaystyle=-E_x/c}
 + \underbrace{\partial^2\left(\partial^1 A^2 + \partial^2 A^1\right)
 	- \partial^3\left(\partial^3 A^1 + \partial^1 A^3\right)}_{\displaystyle=(\nabla\times\vec{B})_x}\biggr)
 =
@@ -273,7 +321,7 @@ J^1  -\frac{1}{\mu_0}\biggl(\partial^0\underbrace{\left(\partial^0 A^1 + \partia
 
 {\larger\textcircled{\smaller[2]3}} $i = 2$
 \[
-J^2  -\frac{1}{\mu_0}\biggl(\partial^0\underbrace{\left(\partial^0 A^2 + \partial^2 A^0\right)}_{\displaystyle=-E_y/c}
+J^2  -\frac{1}{\mu_0}\,\biggl(\partial^0\underbrace{\left(\partial^0 A^2 + \partial^2 A^0\right)}_{\displaystyle=-E_y/c}
 + \underbrace{\partial^3\left(\partial^2 A^3 + \partial^3 A^2\right)
 	- \partial^1\left(\partial^1 A^2 + \partial^2 A^1\right)}_{\displaystyle=(\nabla\times\vec{B})_y}\biggr)
 =
@@ -282,7 +330,7 @@ J^2  -\frac{1}{\mu_0}\biggl(\partial^0\underbrace{\left(\partial^0 A^2 + \partia
 
 {\larger\textcircled{\smaller[2]4}} $i = 3$
 \[
-J^3  -\frac{1}{\mu_0}\biggl(\partial^0\underbrace{\left(\partial^0 A^3 + \partial^3 A^0\right)}_{\displaystyle=-E_z/c}
+J^3  -\frac{1}{\mu_0}\,\biggl(\partial^0\underbrace{\left(\partial^0 A^3 + \partial^3 A^0\right)}_{\displaystyle=-E_z/c}
 + \underbrace{\partial^1\left(\partial^3 A^1 + \partial^1 A^3\right)
 	- \partial^2\left(\partial^2 A^3 + \partial^3 A^2\right)}_{\displaystyle=(\nabla\times\vec{B})_z}\biggr)
 =
@@ -291,7 +339,7 @@ J^3  -\frac{1}{\mu_0}\biggl(\partial^0\underbrace{\left(\partial^0 A^3 + \partia
 
 Für $i=0$ resultiert die partielle Differentialgleichung
 \begin{align}
--c\varrho + \frac{1}{\mu_0\,c}\biggl(\frac{\partial E_x}{\partial x}
+-c\varrho + \frac{1}{\mu_0\,c}\,\biggl(\frac{\partial E_x}{\partial x}
 + \frac{\partial E_y}{\partial y} + \frac{\partial E_z}{\partial z}\biggr)
 &=
 0\\[1em]

--- a/buch/papers/maxwell/elektrodynamik.tex
+++ b/buch/papers/maxwell/elektrodynamik.tex
@@ -7,6 +7,14 @@
 % !TEX encoding = UTF-8
 %
 %Elektrodynmaik
+\tikzset{>=latex} % for LaTeX arrow head
+\colorlet{myblue}{black!40!blue}
+\colorlet{myred}{black!40!red}
+\colorlet{vcol}{green!50!black}
+\colorlet{Ecol}{orange!90!black}
+\colorlet{EVcol}{orange!80!black!60}
+\colorlet{Bcol}{violet!90}
+
 \section{Elektrodynamik\label{section:maxwell:elektrodynmaik}}
 \rhead{Elektrodynamik}
 In der Elektrodynamik erlauben wir, dass
@@ -24,7 +32,7 @@ Daraus folgen einige spannende Tatsachen, auf die wir später noch zu Sprechen k
 Im folgenden werden wir unseren Raum definieren und bekannte Vektorfelder in ihrer Definition anpassen.
 
 \subsubsection{Der vierdimensionale Raum}
-Den Raum in dem wir uns nun bewegen werden, definieren als
+Den Raum in dem wir uns nun bewegen werden, definieren wir als
 \begin{equation}
 	\Omega
 	=
@@ -347,7 +355,7 @@ Für $i=0$ resultiert die partielle Differentialgleichung
 \frac{\varrho}{\varepsilon_0},
 \label{maxwell:section:gauss_dynamisch}
 \end{align}
-was dem dynamischen gaussschen Gesetz entspricht.
+was dem dynamischen gaussschen Gesetz des elektrischen Feldes entspricht.
 Für $i=1,2,3$ resultiert das partielle Differentialgleichungssystem
 \begin{align}
 \vec{\jmath} + \frac{1}{\mu_0\,c^2}\frac{\partial \vec{E}}{\partial t}
@@ -370,8 +378,148 @@ Was können wir aus diesen zwei partiellen Differentialgleichungen entnehmen?
 In der Gleichung \eqref{maxwell:section:gauss_dynamisch} sehen wir, dass das gausssche Gesetz im statischen wie auch im dynamischen Fall von der gleichen Form ist.
 Das heisst die Quelle des elektrischen Feldes ist eine Ladungsdichte $\varrho$.
 In der Gleichung \eqref{maxwell:section:ampere_dynamisch} fällt auf, dass das dynamische ampersche Gesetz, im Vergleich zum statischen, einen zusätzlichen Term erhalten hat, der eine zeitliche Veränderung des elektrischen Feldes beinhaltet.
-Also verursacht nicht nur eine Stromdichte, sondern auch eine zeitliche Veränderung im elektrischen Feld eine Rotation im magnetischen Feld. An dieser Stelle bemerken wir zum ersten Mal, dass das magnetische Feld vom elektrischen Feld beeinflusst werden kann.
+Also verursacht nicht nur eine Stromdichte, sondern auch eine zeitliche Veränderung im elektrischen Feld eine Rotation im magnetischen Feld.
+An dieser Stelle bemerken wir zum ersten Mal, dass das magnetische Feld vom elektrischen Feld beeinflusst werden kann.
 
+
+\subsubsection{Gausssches Gesetz des magnetischen Feldes und Faradaysches Gesetz}
+Der Vollständigkeit halber wollen wir noch einige Worte über die bisher nicht explizit erwähnten Maxwell-Gleichungen verlieren.
+Die beiden Gesetze folgen ganz simpel aus der Definition des elektrischen und magnetischen Feldes.
+ 
+Wenn wir in Gleichung \eqref{maxwell:section:definition_dynamisch_magnetischesFeld} auf beiden Seiten die Divergenz anwenden, erhalten wir
+\[
+\nabla \cdot \vec{B}
+=
+\nabla \cdot (\nabla \times \vec{A}).
+\]
+Da die Divergenz eines Rotationsfeldes immer null ist folgt direkt, dass
+\begin{equation}
+\nabla \cdot \vec{B}
+=
+0
+\label{maxwell:section:Gauss_magnetisches_Feld}
+\end{equation}
+gelten muss.
+Dies entspricht dem gaussschen Gesetz des magnetischen Feldes.
+Es besagt, dass das magnetische Feld quellenfrei ist oder anders ausgedrückt, dass keine magnetische Monopole existieren. Das Bedeutet auch, dass die magnetischen Feldlinien immer in sich geschlossen sein müssen.
+ 
+Wenn wir in Gleichung \eqref{maxwell:section:definiton_dynamisch_elektrischesFeld} auf beiden Seiten die Rotation anwenden, erhalten wir
+\[
+\nabla \times \vec{E}
+=
+\nabla \times \left(- \nabla \varphi\right) - \nabla \times \biggl(\frac{\partial \vec{A}}{\partial t}\biggr).
+\]
+Wir sehen direkt, dass die Rotation eines Gradientenfeldes immer null ist und somit verschwindet der erste Term.
+Da die partielle Ableitung nach der Zeit eine lineare Operation ist, können wir die Reihenfolge der Operationen im zweiten Term vertauschen und die Gleichung wird zu
+\begin{equation}
+\nabla \times \vec{E}
+=
+- \frac{\partial}{\partial t} (\nabla \times \vec{A})
+=
+- \frac{\partial \vec{B}}{\partial t}.
+\end{equation}
+Was wir erhalten ist das faradaysche Gesetz der Induktion.
+Diese partielle Differentialgleichungen sagen uns, dass eine zeitliche Veränderung des magnetischen Feldes eine Rotation des elektrischen Feldes verursacht. Also sehen wir, dass auch das elektrische Feld vom magnetischen Feld beeinflusst werden kann. Da sich in der Elektrodynamik eine zeitliche Veränderung in einem Feld eine Rotation im anderen Feld zur Folge hat, ist die Existenz von elektromagnetischen Wellen gar nicht so weit hergeholt. 
+
+
+\subsubsection{Exkurs zu elektromagnetischen Wellen}
+
+\begin{figure}
+	\centering
+	\begin{tikzpicture}[x=(-15:0.9), y=(90:0.9), z=(-150:1.1),
+		line cap=round, line join=round,
+		axis/.style={black, thick,->},
+		vector/.style={>=stealth,->}]
+		\large
+		\def\A{1.5}
+		\def\nNodes{5} % use even number
+		\def\nVectorsPerNode{8}
+		\def\N{\nNodes*40}
+		\def\xmax{\nNodes*pi/2*1.01}
+		\pgfmathsetmacro\nVectors{(\nVectorsPerNode+1)*\nNodes}
+		\def\vE{{\color{Ecol}\mathbf{E}}}
+		\def\vB{{\color{Bcol}\mathbf{B}}}
+		
+		\def\drawENode{ % draw E node and vectors with some offset
+			\draw[Ecol,very thick,variable=\t,domain=\iOffset*pi/2:(\iOffset+1)*pi/2*1.01,samples=40]
+			plot (\t,{\A*sin(\t*360/pi)},0);
+			\foreach \k [evaluate={\t=\k*pi/2/(\nVectorsPerNode+1);
+				\angle=\k*90/(\nVectorsPerNode+1);}]
+			in {1,...,\nVectorsPerNode}{
+				\draw[vector,EVcol]  (\iOffset*pi/2+\t,0,0) -- ++(0,{\A*sin(2*\angle+\iOffset*180)},0);
+			}
+		}
+		\def\drawBNode{ % draw B node and vectors with some offset
+			\draw[Bcol,very thick,variable=\t,domain=\iOffset*pi/2:(\iOffset+1)*pi/2*1.01,samples=40]
+			plot (\t,0,{\A*sin(\t*360/pi)});
+			\foreach \k [evaluate={\t=\k*pi/2/(\nVectorsPerNode+1);
+				\angle=\k*90/(\nVectorsPerNode+1);}]
+			in {1,...,\nVectorsPerNode}{
+				\draw[vector,Bcol!50]  (\iOffset*pi/2+\t,0,0) -- ++(0,0,{\A*sin(2*\angle+\iOffset*180)});
+			}
+		}
+		
+		% MAIN AXES
+		\draw[axis] (0,0,0) -- ++(\xmax*1.1,0,0) node[right] {$z$};
+		\draw[axis] (0,-\A*1.2,0) -- (0,\A*1.2,0) node[right] {$x$};
+		\draw[axis] (0,0,-\A*1.2) -- (0,0,\A*1.2) node[left] {$y$};
+		
+		% SMALL AXES
+		\def\xOffset{{(\nNodes-2)*pi/2}}
+		\def\yOffset{\A*1.1}
+		\def\zOffset{\A*1.1}
+		\draw[axis,very thick,vcol] (\xOffset,\yOffset,-\zOffset) -- ++(\A*0.6,0,0) node[right,align=center] {$\vb{v}$}; %\\propagation
+		\draw[axis,very thick,Ecol]  (\xOffset,\yOffset,-\zOffset) -- ++(0,\A*0.6,0) node[right] {$\vb{E}$};
+		\draw[axis,very thick,Bcol]   (\xOffset,\yOffset,-\zOffset) -- ++(0,0,\A*0.6) node[left] {$\vb{B}$};
+		
+		% draw (anti-)nodes
+		\foreach \iNode [evaluate={\iOffset=\iNode-1;}] in {1,...,\nNodes}{
+			\ifodd\iNode \drawBNode \drawENode % E overlaps B
+			\else        \drawENode \drawBNode % B overlaps E
+			\fi
+		}
+	\end{tikzpicture}
+	\caption{Elektromagnetische Welle im Vakuum}
+	\label{maxwell:section:bild_em_welle}
+\end{figure}
+In einem luftleeren Raum, wo keine Stromdichte $\vec{\jmath}$ und keine Ladungsdichte $\varrho$ existieren, gilt
+\begin{align}
+\nabla \times \vec{B}
+&=
+\varepsilon_0\,\mu_0 \frac{\partial \vec{E}}{\partial t}
+\label{maxwell:section:ampere_vakuum}
+\\
+\nabla \times \vec{E}
+&=
+-\frac{\partial \vec{B}}{\partial t}.
+\label{maxwell:section:faraday_vakuum}
+\end{align}
+Nun können wir in Gleichung \eqref{maxwell:section:ampere_vakuum} die Rotation auf beiden Seiten anwenden und mithilfe der Grassmann-Identität resultiert
+\begin{align*}
+\nabla \times \nabla \times \vec{B}
+&=
+\varepsilon_0\,\mu_0 \frac{\partial}{\partial t} (\nabla \times \vec{E})\\
+\Leftrightarrow \qquad \nabla \underbrace{(\nabla \cdot \vec{B})}_{\displaystyle=0} - \Delta \vec{B}
+&=
+-\varepsilon_0\,\mu_0 \frac{\partial ^2 \vec{B}}{\partial t^2}\\
+\Leftrightarrow \qquad \frac{\partial ^2 \vec{B}}{\partial t^2}
+&=
+\underbrace{\frac{1}{\varepsilon_0\,\mu_0}}_{\displaystyle=c^2} \Delta \vec{B}.
+\end{align*}
+Dies entspricht genau der Wellengleichung.
+Mit dem gleichen Vorgehen resultiert für die Gleichung \eqref{maxwell:section:faraday_vakuum}
+\begin{align*}
+\nabla \times \nabla \times \vec{E}
+&=
+- \frac{\partial}{\partial t} (\nabla \times \vec{B})\\
+\Leftrightarrow \qquad \nabla \underbrace{(\nabla \cdot \vec{E})}_{\displaystyle=0} - \Delta \vec{E}
+&=
+- \varepsilon_0\,\mu_0 \frac{\partial ^2 \vec{E}}{\partial t^2}\\
+\Leftrightarrow \qquad \frac{\partial ^2 \vec{E}}{\partial t^2}
+&=
+\underbrace{\frac{1}{\varepsilon_0\,\mu_0}}_{\displaystyle=c^2} \Delta \vec{E}.
+\end{align*}
+Wir kommen also zum Schluss, dass beide Felder die Wellengleichung im genannten Raum erfüllen. Eine Lösung der Wellengleichung kann wie in Abbildung \ref{maxwell:section:bild_em_welle} aussehen. Was dabei auffällt ist, dass die Ausbreitungsgeschwindigkeit in beiden Fällen die Lichtgeschwindigkeit $c$ ist. Daraus kann man schliessen, dass Licht eine elektromagnetische Welle ist.
 
 
 

--- a/buch/papers/maxwell/elektrodynamik.tex
+++ b/buch/papers/maxwell/elektrodynamik.tex
@@ -24,7 +24,7 @@ Daraus folgen einige spannende Tatsachen, auf die wir später noch zu Sprechen k
 Im folgenden werden wir unseren Raum definieren und bekannte Vektorfelder in ihrer Definition anpassen.
 
 \subsubsection{Der vierdimensionale Raum}
-Den Raum in dem wir uns nun bewegen werden wir definieren als
+Den Raum in dem wir uns nun bewegen werden, definieren als
 \begin{equation}
 	\Omega
 	=
@@ -162,7 +162,7 @@ und
 \vec{A}\cdot\vec{\jmath}
 \)
 sind.
-Hiermit ist es uns noch nicht gelungen ein Energiefunktional zu formulieren, das von der Form
+Hiermit ist es uns allerdings noch nicht gelungen ein Energiefunktional zu formulieren, welches von der Form
 \[
 I(f) = \int_{t_0}^{t_1} \int_{z_0}^{z_1} \int_{y_0}^{y_1} \int_{x_0}^{x_1} L(t,x,y,z,f,f_t,f_x,f_y,f_z)\,dx\,dy\,dz\,dt 
 \]
@@ -291,7 +291,7 @@ L(\Omega^0,...,\Omega^3, A^0,...,A^3, \partial^0 A^i,...,\partial^3 A^i)
 \end{align*}
 
 \subsubsection{Einsetzen in die Euler-Ostrogradski-Differentialgleichung}
-Da unsere Lagrange-Funktion von einer Vektorgrösse abhängig ist erhalten wir eine Euler-Ostrogradski-Differentialgleichung von der Form
+Da unsere Lagrange-Funktion wiederum von einer Vektorgrösse abhängig ist erhalten wir diesmal vier Euler-Ostrogradski-Differentialgleichung von der Form
 \[
 \frac{\partial L}{\partial A^i} 
 - \frac{\partial}{\partial \Omega^0}\frac{\partial L}{\partial(\partial^0 A^i)}
@@ -336,7 +336,6 @@ J^3  -\frac{1}{\mu_0}\,\biggl(\partial^0\underbrace{\left(\partial^0 A^3 + \part
 =
 0
 \]
-
 Für $i=0$ resultiert die partielle Differentialgleichung
 \begin{align}
 -c\varrho + \frac{1}{\mu_0\,c}\,\biggl(\frac{\partial E_x}{\partial x}

--- a/buch/papers/maxwell/elektrodynamik.tex
+++ b/buch/papers/maxwell/elektrodynamik.tex
@@ -126,7 +126,7 @@ Das magnetische Feld
 \(
 \vec{B}: \mathbb{R}^4 \rightarrow \mathbb{R}^3
 \)
-wird in der Elektrodynamik ähnlich definiert wie in der Magnetostatik. Nämlich ist
+wird in der Elektrodynamik ähnlich definiert wie in der Magnetostatik. Nämlich als
 \begin{equation}
 	\vec{B}(t,x,y,z)
 	=
@@ -182,7 +182,7 @@ Dieses neue Vektorfeld heisst elektromagnetisches 4er Potential
 \(
 A:\mathbb{R}^4 \rightarrow \mathbb{R}^4
 \)
-und wird definiert als
+und wird als
 \begin{equation}
 	A
 	=
@@ -195,7 +195,7 @@ und wird definiert als
 	=
 	A^{\mu},
 \end{equation}
-wobei $A_x$, $A_y$, $A_z$ die Komponenten des magnetischen Vektorpotentiales $\vec{A}$ sind.
+definiert, wobei $A_x$, $A_y$, $A_z$ die Komponenten des magnetischen Vektorpotentiales $\vec{A}$ sind.
 Mittels dieser Grösse können wir nun das elektrische und magnetische Feld ausdrücken.
 Also
 \begin{equation}
@@ -299,7 +299,7 @@ L(\Omega^0,...,\Omega^3, A^0,...,A^3, \partial^0 A^i,...,\partial^3 A^i)
 \end{align*}
 
 \subsubsection{Einsetzen in die Euler-Ostrogradski-Differentialgleichung}
-Da unsere Lagrange-Funktion wiederum von einer Vektorgrösse abhängig ist erhalten wir diesmal vier Euler-Ostrogradski-Differentialgleichung von der Form
+Da unsere Lagrange-Funktion wiederum von einer vektoriellen Grösse abhängig ist, erhalten wir diesmal vier Euler-Ostrogradski-Differentialgleichungen von der Form
 \[
 \frac{\partial L}{\partial A^i} 
 - \frac{\partial}{\partial \Omega^0}\frac{\partial L}{\partial(\partial^0 A^i)}
@@ -377,7 +377,7 @@ Eine wunderschöne Tatsache, denn einmal mehr wurden wir Zeuge davon, dass wenn 
 Was können wir aus diesen zwei partiellen Differentialgleichungen entnehmen?
 In der Gleichung \eqref{maxwell:section:gauss_dynamisch} sehen wir, dass das gausssche Gesetz im statischen wie auch im dynamischen Fall von der gleichen Form ist.
 Das heisst die Quelle des elektrischen Feldes ist eine Ladungsdichte $\varrho$.
-In der Gleichung \eqref{maxwell:section:ampere_dynamisch} fällt auf, dass das dynamische ampersche Gesetz, im Vergleich zum statischen, einen zusätzlichen Term erhalten hat, der eine zeitliche Veränderung des elektrischen Feldes beinhaltet.
+In der Gleichung \eqref{maxwell:section:ampere_dynamisch} fällt auf, dass das dynamische ampèrsche Gesetz, im Vergleich zum statischen, einen zusätzlichen Term erhalten hat, der eine zeitliche Veränderung des elektrischen Feldes beinhaltet.
 Also verursacht nicht nur eine Stromdichte, sondern auch eine zeitliche Veränderung im elektrischen Feld eine Rotation im magnetischen Feld.
 An dieser Stelle bemerken wir zum ersten Mal, dass das magnetische Feld vom elektrischen Feld beeinflusst werden kann.
 
@@ -401,7 +401,7 @@ Da die Divergenz eines Rotationsfeldes immer null ist folgt direkt, dass
 \end{equation}
 gelten muss.
 Dies entspricht dem gaussschen Gesetz des magnetischen Feldes.
-Es besagt, dass das magnetische Feld quellenfrei ist oder anders ausgedrückt, dass keine magnetische Monopole existieren. Das Bedeutet auch, dass die magnetischen Feldlinien immer in sich geschlossen sein müssen.
+Es besagt, dass das magnetische Feld quellenfrei ist oder anders ausgedrückt, dass keine magnetische Monopole existieren. Was wiederum auch bedeutet, dass die magnetischen Feldlinien immer in sich geschlossen sein müssen.
  
 Wenn wir in Gleichung \eqref{maxwell:section:definiton_dynamisch_elektrischesFeld} auf beiden Seiten die Rotation anwenden, erhalten wir
 \[
@@ -419,7 +419,7 @@ Da die partielle Ableitung nach der Zeit eine lineare Operation ist, können wir
 - \frac{\partial \vec{B}}{\partial t}.
 \end{equation}
 Was wir erhalten ist das faradaysche Gesetz der Induktion.
-Diese partielle Differentialgleichungen sagen uns, dass eine zeitliche Veränderung des magnetischen Feldes eine Rotation des elektrischen Feldes verursacht. Also sehen wir, dass auch das elektrische Feld vom magnetischen Feld beeinflusst werden kann. Da sich in der Elektrodynamik eine zeitliche Veränderung in einem Feld eine Rotation im anderen Feld zur Folge hat, ist die Existenz von elektromagnetischen Wellen gar nicht so weit hergeholt. 
+Diese partielle Differentialgleichungen sagen uns, dass eine zeitliche Veränderung des magnetischen Feldes eine Rotation des elektrischen Feldes verursacht. Also sehen wir, dass auch das elektrische Feld vom magnetischen Feld beeinflusst werden kann. Da sich in der Elektrodynamik eine zeitliche Veränderung in einem Feld eine Rotation im anderen Feld zur Folge hat, ist die Existenz von elektromagnetischen Wellen auch intuitiv erklärbar. 
 
 
 \subsubsection{Exkurs zu elektromagnetischen Wellen}
@@ -482,7 +482,7 @@ Diese partielle Differentialgleichungen sagen uns, dass eine zeitliche Veränder
 	\caption{Elektromagnetische Welle im Vakuum}
 	\label{maxwell:section:bild_em_welle}
 \end{figure}
-In einem luftleeren Raum, wo keine Stromdichte $\vec{\jmath}$ und keine Ladungsdichte $\varrho$ existieren, gilt
+In einem luftleeren Raum, in welchem keine Stromdichte $\vec{\jmath}$ und keine Ladungsdichte $\varrho$ existieren, gilt
 \begin{align}
 \nabla \times \vec{B}
 &=

--- a/buch/papers/maxwell/elektrostatik_mit_quelle.tex
+++ b/buch/papers/maxwell/elektrostatik_mit_quelle.tex
@@ -81,7 +81,7 @@ Der Kopplungsterm in unserem Fall beschreibt die Wechselwirkung zwischen dem Fel
 Nun können wir diese Lagrange-Funktion in die Euler-Ostrogradski-Differentialgleichung einsetzen, um zu untersuchen, wie sich das elektrische Potentialfeld verhält.
 
 \subsubsection{Einsetzen in die Euler-Ostrogradski-Differentialgleichung}
-Nun wollen wir die in \eqref{maxwell:section:lagrangefunktion_mit_quelle} gefundene Lagrange-Funktion in die Euler-Ostrogradski-Differentialgleichung einsetzten.
+Jetzt wollen wir die in \eqref{maxwell:section:lagrangefunktion_mit_quelle} gefundene Lagrange-Funktion in die Euler-Ostrogradski-Differentialgleichung einsetzten.
 Um die Rechnung übersichtlicher zu gestalten, machen wir uns die Linearität der Euler-Ostrogradski-Differentialgleichung
 \begin{equation}
 F(W_{\text{tot}})

--- a/buch/papers/maxwell/elektrostatik_mit_quelle.tex
+++ b/buch/papers/maxwell/elektrostatik_mit_quelle.tex
@@ -165,7 +165,7 @@ f,
 wobei $\varphi$ ein Potentialfeld und $f$ eine Quelle ist, findet in vielen Teilen der Physik ihre Anwendungen.
 Die Quelle $f$ kann wie in Gleichung \eqref{maxwell:section:erste_maxwellgleichung_1} eine Funktion des Raumes und/oder eine Funktion der Zeit sein.
 Ein Potentialfeld, dass die Poisson-Gleichung erfüllt, führt zu einem Gradientenfeld $\nabla\varphi$, dass die Quelle $f$ besitzt und rotationsfrei ist.
-Die homogene Gleichung, also wo $f = 0$ ist, führt uns zur Laplace-Gleichung.
+Die homogene Gleichung, also jene die $f = 0$ erfüllt, führt uns zur Laplace-Gleichung.
 
 
 

--- a/buch/papers/maxwell/elektrostatik_mit_quelle.tex
+++ b/buch/papers/maxwell/elektrostatik_mit_quelle.tex
@@ -7,14 +7,12 @@
 % !TEX encoding = UTF-8
 %
 %erste Maxwell Gleichung mit Quelle
-\subsection{Gausssches Gesetz
+\subsection{Gausssches Gesetz des elektrischen Feldes
 \label{maxwell:section:elektrostatik_mit_quelle}}
-\rhead{Problemstellung}
 Nun betrachten wir einen luftleeren, dreidimensionalen Raum $V\subset\mathbb{R}^3$, in dem ein elektrisches Potentialfeld $\varphi(x,y,z)$ und eine Ladungsdichte $\varrho(x,y,z)$ existieren.
 Auch für diesen Raum möchten wir mittels Variationsrechnung eine Gleichung finden, die das Verhalten des elektrischen Potentialfeldes beschreibt.
 
 \subsubsection{Ansatz}
-\rhead{Ansatz}
 Es ist naheliegend, dass auch in diesem Szenario die Energie im System minimiert werden muss.
 Wie auch in Gleichung \eqref{maxwell:section:energieintegral_quellenfrei} ist die Energie im elektrischen Feld
 \[
@@ -142,13 +140,13 @@ Dadurch muss
 \label{maxwell:section:erste_maxwellgleichung_2}
 \end{equation}
 gelten.
-Wir sehen, dass dies dem gaussschen Gesetz entspricht.
+Wir sehen, dass dies dem gaussschen Gesetz des elektrischen Feldes entspricht.
 
 \subsubsection{Interpretation des Resultates}
 Das gausssche Gesetz \eqref{maxwell:section:erste_maxwellgleichung_2} besagt, dass die Quelle des elektrischen Feldes eine Ladungsdichte $\varrho$ ist.
 Dies bedeutet, dass elektrische Feldlinien auf Ladungen enden können.
 In anderen Worten wird das elektrostatische Feld durch Ladungen erzeugt!
-Da es sowohl positive wie auch negative Ladungen gibt, gilt dasselbe für die Ladungsdichten.
+Da es sowohl positive wie auch negative Ladungen gibt, existieren demnach auch positive und negative Ladungsdichten.
 Wenn die Ladungsdichte positiv ist, sagt uns die erste Maxwell-Gleichung, dass das elektrische Feld eine Quelle besitzt.
 Das heisst, salopp gesagt, die Feldvektoren zeigen weg von der Ladungsdichte.
 Wenn die Ladungsdichte jedoch negativ ist, besitzt das elektrische Feld eine Senke.

--- a/buch/papers/maxwell/elektrostatik_mit_quelle.tex
+++ b/buch/papers/maxwell/elektrostatik_mit_quelle.tex
@@ -10,7 +10,7 @@
 \subsection{Gausssches Gesetz des elektrischen Feldes
 \label{maxwell:section:elektrostatik_mit_quelle}}
 Nun betrachten wir einen luftleeren, dreidimensionalen Raum $V\subset\mathbb{R}^3$, in dem ein elektrisches Potentialfeld $\varphi(x,y,z)$ und eine Ladungsdichte $\varrho(x,y,z)$ existieren.
-Auch für diesen Raum möchten wir mittels Variationsrechnung eine Gleichung finden, die das Verhalten des elektrischen Potentialfeldes beschreibt.
+Auch für diesen Raum möchten wir mittels der Variationsrechnung eine Gleichung finden, die das Verhalten des elektrischen Potentialfeldes beschreibt.
 
 \subsubsection{Ansatz}
 Es ist naheliegend, dass auch in diesem Szenario die Energie im System minimiert werden muss.

--- a/buch/papers/maxwell/elektrostatik_mit_quelle.tex
+++ b/buch/papers/maxwell/elektrostatik_mit_quelle.tex
@@ -80,21 +80,21 @@ Man bemerkt, dass die Lagrange-Funktion einen zusätzlichen additiven Term erhal
 Solche Terme nennt man Kopplungsterme.
 Sie werden verwendet, um die Wechselwirkung zwischen Termen in der Lagrange-Funktion zu berücksichtigen.
 Der Kopplungsterm in unserem Fall beschreibt die Wechselwirkung zwischen dem Feld und der Ladungsdichte.
-Nun können wir diese Lagrangefunktion in die Euler-Ostrogradski-Differentialgleichung einsetzen, um zu untersuchen, wie sich das elektrische Potentialfeld verhält.
+Nun können wir diese Lagrange-Funktion in die Euler-Ostrogradski-Differentialgleichung einsetzen, um zu untersuchen, wie sich das elektrische Potentialfeld verhält.
 
 \subsubsection{Einsetzen in die Euler-Ostrogradski-Differentialgleichung}
-Nun wollen wir die in \eqref{maxwell:section:lagrangefunktion_mit_quelle} gefundene Lagrangefunktion in die Euler-Ostrogradski-Differentialgleichung einsetzten.
+Nun wollen wir die in \eqref{maxwell:section:lagrangefunktion_mit_quelle} gefundene Lagrange-Funktion in die Euler-Ostrogradski-Differentialgleichung einsetzten.
 Um die Rechnung übersichtlicher zu gestalten, machen wir uns die Linearität der Euler-Ostrogradski-Differentialgleichung
 \begin{equation}
-F\left\{W_{\text{tot}}\right\}
+F(W_{\text{tot}})
 =
-F\left\{W_{\text{e}} - W_{\text{q}}\right\}
+F(W_{\text{e}} - W_{\text{q}})
 =
-F\left\{W_{\text{e}}\right\} + F\left\{-W_{\text{q}}\right\}
+F(W_{\text{e}}) + F(-W_{\text{q}})
 \label{maxwell:section:linearität_von_DGL}
 \end{equation}
 zu nutze.
-Die Lösung von $F\left\{W_{\text{e}}\right\}$ haben wir in Gleichung \eqref{maxwell:section:laplace_gleichung_1} bereits gefunden.
+Die Lösung von $F(W_{\text{e}})$ haben wir in Gleichung \eqref{maxwell:section:laplace_gleichung_1} bereits gefunden.
 Durch einsetzen von $-W_{\text{q}}$ in die Euler-Ostrogradski-Differentialgleichung erhalten wir
 \[
 \frac{\partial}{\partial\varphi}\left(-\varrho\,\varphi\right) - \underbrace{\frac{\partial}{\partial x}\frac{\partial}{\partial\varphi_x}\left(\varrho\,\varphi\right)}_{=0} - \underbrace{\frac{\partial}{\partial y}\frac{\partial}{\partial\varphi_y}\left(\varrho\,\varphi\right)}_{=0} - \underbrace{\frac{\partial}{\partial z}\frac{\partial}{\partial\varphi_z}\left(\varrho\,\varphi\right)}_{=0}
@@ -118,7 +118,7 @@ Durch Addition unserer zwei Teillösungen erhalten wir die Gleichung
 &=
 -\varrho.
 \end{align*}
-Schlussendlich erhalten wir
+Schlussendlich ist
 \begin{equation}
 \Delta\varphi
 =
@@ -126,13 +126,15 @@ Schlussendlich erhalten wir
 \label{maxwell:section:erste_maxwellgleichung_1}
 \end{equation}
 % TODO: definiton des laplace-operators suchen
-Durch gleiches Vorgehen wie in Gleichung \eqref{maxwell:section:laplace_gleichung_3} erhalten wir
+Durch gleiches Vorgehen wie in Gleichung \eqref{maxwell:section:laplace_gleichung_3} erreichen wir, dass
 \[
 \nabla\cdot\underbrace{\nabla\varphi}_{\displaystyle-\vec{E}}
 =
--\frac{\varrho}{\varepsilon_0}.
+-\frac{\varrho}{\varepsilon_0}
 \]
-Somit können wir erneut die Schlussdifferentialgleichung mit dem elektrischen Feld ausdrücken. Dadurch muss
+ist.
+Somit können wir erneut die Schlussdifferentialgleichung mit dem elektrischen Feld ausdrücken.
+Dadurch muss
 \begin{equation}
 \nabla\cdot\vec{E}
 =
@@ -160,9 +162,9 @@ Die Poisson-Gleichung
 =
 f,
 \]
-wobei $\phi$ ein Potentialfeld und $f$ eine Quelle ist, findet in vielen Teilen der Physik ihre Anwendungen.
-Die Quelle $f$ kann wie in Gleichung \eqref{maxwell:section:erste_maxwellgleichung_1} eine Funktion des Raumes und/oder eine Funkiton der Zeit sein.
-Ein Potentialfeld, dass die Poisson-Gleichung erfüllt, führt zu einem Gradientenfeld $\nabla\varphi$, dass die Quelle $f$ besitzt und Rotationsfrei ist.
+wobei $\varphi$ ein Potentialfeld und $f$ eine Quelle ist, findet in vielen Teilen der Physik ihre Anwendungen.
+Die Quelle $f$ kann wie in Gleichung \eqref{maxwell:section:erste_maxwellgleichung_1} eine Funktion des Raumes und/oder eine Funktion der Zeit sein.
+Ein Potentialfeld, dass die Poisson-Gleichung erfüllt, führt zu einem Gradientenfeld $\nabla\varphi$, dass die Quelle $f$ besitzt und rotationsfrei ist.
 Die homogene Gleichung, also wo $f = 0$ ist, führt uns zur Laplace-Gleichung.
 
 

--- a/buch/papers/maxwell/elektrostatik_ohne_quelle.tex
+++ b/buch/papers/maxwell/elektrostatik_ohne_quelle.tex
@@ -29,7 +29,7 @@
 
 \section{Elektrostatik\label{maxwell:section:elekktrostatik}}
 \rhead{Elektrostatik}
-Die Elektrostatik ist ein Spezialfall der Elektrodynamik, bei dem statische Felder betrachtet werden.
+Die Elektrostatik ist ein Spezialfall der Elektrodynamik, bei dem statische, das heisst zeitlich nicht veränderliche Felder betrachtet werden.
 Dies setzt voraus, dass
 \begin{equation}
 	\frac{\partial f}{\partial t}
@@ -103,6 +103,7 @@ Dieses Feld kann man anhand der Kraftwirkung an sogenannten Probeladungen $q$ me
 ist.
 Somit sind die Vektoren in Abbildung \ref{maxwell:section:E-Feld_punktladung} Kraftvektoren, welche normiert sind auf die Ladung $q$.
 %E-Field of point charge
+%TODO: Bild grösser oder nur nodes grösser?
 \begin{figure}
 	\centering
 	\begin{tikzpicture}
@@ -125,7 +126,6 @@ Somit sind die Vektoren in Abbildung \ref{maxwell:section:E-Feld_punktladung} Kr
 		\node[EcolFL,scale=0.8] at (1.4,-1.4) {$\vec{E}$};
 		\node[EcolEP,scale=0.8] at (1.95,0) {$\varphi$};
 	\end{tikzpicture}
-	%TODO: Caption anpassen
 	\caption{Elektrisches Feld (grün) einer positiven Punktladung $+Q$ und Äquipotentiallinien (blau) der selben positiven Punktladung $+Q$}
 	\label{maxwell:section:E-Feld_punktladung}
 \end{figure}
@@ -149,11 +149,11 @@ Die Permittivität
 \)
 ist ein Mass dafür, wie gut sich ein Material polarisieren lässt und ist das Produkt der relativen Permittivität $\varepsilon_r$ und der Permittivität von Vakuum $\varepsilon_0$.
 Die relative Permittivität ist eine materialabhängige Grösse und hat in Vakuum den skalaren Wert $1$.
-Die Permittivität des Vakuums
+Die Permittivität des Vakuums in SI-Einheiten
 \[
 \varepsilon_0
 =
-8.854 \cdot 10^{-12} F/m
+8.854 \cdot 10^{-12}\,\text{F/m}
 \]
 ist die elektrische Feldkonstante.
 
@@ -163,7 +163,7 @@ ist die elektrische Feldkonstante.
 \rhead{Problemstellung}
 Man stelle sich nun einen ladungsfreien, luftleeren, drei dimensionalen Raum $V\subset\mathbb{R}^3$
 vor, indem ein elektrisches Potentialfeld $\varphi(x,y,z)$ existiert.
-Für diesen Raum möchten wir mittels der Varitaionsrechnung eine partielle Differentialgleichung entwickeln, die beschreibt, wie sich das Potentialfeld und somit auch das elektrische Feld verhält. 
+Für diesen Raum möchten wir mittels der Variationsrechnung eine partielle Differentialgleichung entwickeln, die beschreibt, wie sich das Potentialfeld und somit auch das elektrische Feld verhält. 
 
 \subsubsection{Ansatz}
 Damit wir eine Gleichung erhalten, die das Verhalten des elektrischen Potentialfeldes beschreibt, muss ganz allgemein die Energie im System minimiert werden. 
@@ -189,7 +189,7 @@ w_{\text{e}}
 \frac{1}{2}\,\varepsilon_0\left(-\nabla\varphi\right)^2
 \\
 w_{\text{e}}
-=
+&=
 \frac{1}{2}\,\varepsilon_0
 \begin{pmatrix}
 \displaystyle
@@ -199,7 +199,7 @@ w_{\text{e}}
 \displaystyle
 -\varphi_z
 \end{pmatrix}
-&\cdot
+\cdot
 \begin{pmatrix}
 \displaystyle
 -\varphi_x\\
@@ -213,7 +213,6 @@ w_{\text{e}}
 \label{maxwell:section:energiedichte}
 \end{align}
 Dies können wir in das zu minimerende Integral einsetzen und bekommen
-%TODO: eventuell underbraces weg lassen.
 \begin{equation}
 	W_{\text{e}}
 	=
@@ -232,16 +231,15 @@ ist.
 Somit haben wir unsere Lagrange-Funktion gefunden, die wir in einem nächsten Schritt in die Euler-Ostrogradski-Differentialgleichung einsetzen können.
 
 \subsubsection{Einsetzen in die Euler-Ostrogradski-Differentialgleichung}
-%TODO: label suchen von E-O-DGL von müller kapitel
 Nun gilt es die in \eqref{maxwell:section:lagrangefunktion_quellenfrei} gefundene Gleichung in die Euler-Ostrogradski-Differentialgleichung \eqref{buch:felder:ostrogradski:eqn:euler-ostrogradski} einzusetzen.
 Nach Einsetzen wird die Differentialgleichung zu
-\[
-\frac{1}{2}\,\varepsilon_0\,\biggl(\underbrace{\frac{\partial}{\partial\varphi}\left(\varphi_x^2 + \varphi_y^2 + \varphi_z^2\right)}_{\displaystyle=0} - \frac{\partial}{\partial x}\frac{\partial}{\partial \varphi_x}\left(\varphi_x^2 + \varphi_y^2 + \varphi_z^2\right) - 
-\frac{\partial}{\partial y}\frac{\partial}{\partial \varphi_y}\left(\varphi_x^2 + \varphi_y^2 + \varphi_z^2\right) - 
+\begin{align*}
+\frac{1}{2}\,\varepsilon_0\,\biggl(\underbrace{\frac{\partial}{\partial\varphi}\left(\varphi_x^2 + \varphi_y^2 + \varphi_z^2\right)}_{\displaystyle=0} &- \frac{\partial}{\partial x}\frac{\partial}{\partial \varphi_x}\left(\varphi_x^2 + \varphi_y^2 + \varphi_z^2\right)\\
+&- \frac{\partial}{\partial y}\frac{\partial}{\partial \varphi_y}\left(\varphi_x^2 + \varphi_y^2 + \varphi_z^2\right) - 
 \frac{\partial}{\partial z}\frac{\partial}{\partial \varphi_z}\left(\varphi_x^2 + \varphi_y^2 + \varphi_z^2\right)\biggr)
 =
 0.
-\]
+\end{align*}
 Man sieht, dass die partielle Ableitung nach $\varphi$ verschwindet.
 Nach den partiellen Ableitungen nach $\varphi_x$, $\varphi_y$ und $\varphi_z$ wird die Differentialgleichung zu
 \[
@@ -267,7 +265,7 @@ Somit wird unsere Schlussdifferentialgleichung zu
 	\label{maxwell:section:laplace_gleichung_2}
 \end{equation}
 %TODO: Definition Laplace suchen.
-Wenn wir nun den Laplace-Operator laut seiner Definition \eqref{???} mittels Divergenz und Gradient ausdrücken, erhalten wir die Gleichung
+Wenn wir nun den Laplace-Operator laut seiner Definition \eqref{buch:felder:fundamentallemma:eqn:laplaceproduktformel} mittels Divergenz und Gradient ausdrücken, erhalten wir die Gleichung
 \begin{equation}
 \nabla\cdot\underbrace{\nabla\varphi}_{\displaystyle-\vec{E}}
 =

--- a/buch/papers/maxwell/elektrostatik_ohne_quelle.tex
+++ b/buch/papers/maxwell/elektrostatik_ohne_quelle.tex
@@ -103,11 +103,10 @@ Dieses Feld kann man anhand der Kraftwirkung an sogenannten Probeladungen $q$ me
 ist.
 Somit sind die Vektoren in Abbildung \ref{maxwell:section:E-Feld_punktladung} Kraftvektoren, welche normiert sind auf die Ladung $q$.
 %E-Field of point charge
-%TODO: Bild grösser oder nur nodes grösser?
 \begin{figure}
 	\centering
 	\begin{tikzpicture}
-		\def\R{1.8}
+		\def\R{2.2}
 		\def\NE{16}
 		\def\NV{4}
 		\contourlength{1.6pt}
@@ -119,12 +118,12 @@ Somit sind die Vektoren in Abbildung \ref{maxwell:section:E-Feld_punktladung} Kr
 		\foreach \i [evaluate={\angle=(\i-1)*360/\NE;}] in {1,...,\NE}{
 			\draw[EFieldLineArrow={0.6}] (0,0) -- (\angle:\R);
 		}
-		\draw[charge+] (0,0) circle (7pt) node[black,scale=0.8] {$+Q$};
+		\draw[charge+] (0,0) circle (8pt) node[black,scale=1] {$+Q$};
 		%\draw[FFieldLineArrow={0.6}] (-1,1) -- (-2,2);
-		\draw[-{Stealth[black]}] (-1,1) -- (-1.8,1.8) node at (-1.6, 2) {$\vec{F}$};
-		\draw[charge_small] (-1,1) circle (4pt) node[black,scale=0.8] {$q$};
-		\node[EcolFL,scale=0.8] at (1.4,-1.4) {$\vec{E}$};
-		\node[EcolEP,scale=0.8] at (1.95,0) {$\varphi$};
+		\draw[-{Stealth[black]}] (-1.2,1.2) -- (-2,2) node at (-1.6, 2) {$\vec{F}$};
+		\draw[charge_small] (-1.2,1.2) circle (5pt) node[black,scale=1] {$q$};
+		\node[EcolFL,scale=1] at (1.8,-1.8) {$\vec{E}$};
+		\node[EcolEP,scale=1] at (2.5,0) {$\varphi$};
 	\end{tikzpicture}
 	\caption{Elektrisches Feld (grün) einer positiven Punktladung $+Q$ und Äquipotentiallinien (blau) der selben positiven Punktladung $+Q$}
 	\label{maxwell:section:E-Feld_punktladung}
@@ -172,7 +171,7 @@ W_{\text{e}}
 \iiint_V w_e\, dV.
 \]
 Dieses Integral gilt es zu minimieren, was die Grundlage für unser Variationsproblem darstellt.
-Die in \eqref{maxwell:section:definiton_energiedichte_elektrischesFeld} definierte Energiedichte ist im Vakuum
+Die in \eqref{maxwell:section:definiton_energiedichte_elektrischesFeld} definierte Energiedichte ist in Vakuum
 \[
 w_{\text{e}}
 =
@@ -244,7 +243,7 @@ Nachdem wir die partiellen Ableitungen nach $\varphi_x$, $\varphi_y$ und $\varph
 =
 0.
 \]
-Wenn man nun noch die letzten partiellen Ableitungen macht, wird die Differentialgleichung zu
+Wenn man nun noch die letzten partiellen Ableitungen macht, resultiert
 \begin{equation}
 	- \varepsilon_0\underbrace{\left(\frac{\partial^2\varphi}{\partial x^2} + \frac{\partial^2\varphi}{\partial y^2} + \frac{\partial^2\varphi}{\partial z^2}\right)}_{\displaystyle=0}
 	=

--- a/buch/papers/maxwell/elektrostatik_ohne_quelle.tex
+++ b/buch/papers/maxwell/elektrostatik_ohne_quelle.tex
@@ -157,10 +157,8 @@ Die Permittivität des Vakuums in SI-Einheiten
 \]
 ist die elektrische Feldkonstante.
 
-%TODO: Anderer Titelname
 \subsection{Laplace-Gleichung
 	\label{maxwell:section:elektrostatik_ohne_quelle}}
-\rhead{Problemstellung}
 Man stelle sich nun einen ladungsfreien, luftleeren, drei dimensionalen Raum $V\subset\mathbb{R}^3$
 vor, indem ein elektrisches Potentialfeld $\varphi(x,y,z)$ existiert.
 Für diesen Raum möchten wir mittels der Variationsrechnung eine partielle Differentialgleichung entwickeln, die beschreibt, wie sich das Potentialfeld und somit auch das elektrische Feld verhält. 
@@ -216,8 +214,7 @@ Dies können wir in das zu minimerende Integral einsetzen und bekommen
 \begin{equation}
 	W_{\text{e}}
 	=
-	\iiint_V \underbrace{
-		\frac{1}{2}\,\varepsilon_0\left(\varphi_x^2 + \varphi_y^2 + \varphi_z^2\right)}_{\displaystyle=L(x,y,z,\varphi,\varphi_x,\varphi_y,\varphi_z)}\, dV.
+	\iiint_V \frac{1}{2}\,\varepsilon_0\left(\varphi_x^2 + \varphi_y^2 + \varphi_z^2\right)\, dV.
 	\label{maxwell:section:energieintegral_quellenfrei}
 \end{equation}
 Aus dieser Gleichung können wir entnehmen, dass unsere Lagrange-Funktion

--- a/buch/papers/maxwell/elektrostatik_ohne_quelle.tex
+++ b/buch/papers/maxwell/elektrostatik_ohne_quelle.tex
@@ -179,7 +179,7 @@ w_{\text{e}}
 \frac{1}{2}\,\varepsilon_0\,\vec{E}\,^2.
 \]
 Diese Gleichung können wir nun mittels Definition \eqref{maxwell:section:definition_statisch_elektrischesFeld} mit dem elektrischen Potentialfeld ausdrücken.
-somit ist
+Folglich ist
 \begin{align}
 \renewcommand{\arraystretch}{1.9}
 w_{\text{e}}
@@ -238,7 +238,7 @@ Nach Einsetzen wird die Differentialgleichung zu
 0.
 \end{align*}
 Man sieht, dass die partielle Ableitung nach $\varphi$ verschwindet.
-Nach den partiellen Ableitungen nach $\varphi_x$, $\varphi_y$ und $\varphi_z$ wird die Differentialgleichung zu
+Nachdem wir die partiellen Ableitungen nach $\varphi_x$, $\varphi_y$ und $\varphi_z$ durchgeführt haben, wird die Differentialgleichung zu
 \[
 \frac{1}{2}\,\varepsilon_0\left(-\frac{\partial}{\partial x}2\varphi_x - \frac{\partial}{\partial y}2\varphi_y - \frac{\partial}{\partial z}2\varphi_z\right)
 =

--- a/buch/papers/maxwell/elektrostatik_ohne_quelle.tex
+++ b/buch/papers/maxwell/elektrostatik_ohne_quelle.tex
@@ -180,7 +180,7 @@ w_{\text{e}}
 =
 \frac{1}{2}\,\varepsilon_0\,\vec{E}\,^2.
 \]
-Diese Gleichung können wir nun mittels definition \eqref{maxwell:section:definition_statisch_elektrischesFeld} mit dem elektrischen Potentialfeld ausdrücken.
+Diese Gleichung können wir nun mittels Definition \eqref{maxwell:section:definition_statisch_elektrischesFeld} mit dem elektrischen Potentialfeld ausdrücken.
 somit ist
 \begin{align}
 \renewcommand{\arraystretch}{1.9}
@@ -281,7 +281,7 @@ Dank der statischen Definition des elektrischen Feldes \eqref{maxwell:section:de
 \end{equation}
 sein muss. Diese Differentialgleichung besagt, dass das elektrische Feld quellenfrei ist.
 Dies bedeutet, dass Felldlinien des elektrischen Feldes an keinem Ort im Raum enstehen oder enden können.
-Dies ist sehr naheliegend, da ohne Ladungen im Raum das elektrische Feld quellenfrei sein muss.
+Was wiederum sehr naheliegend ist, da ohne Ladungen im Raum das elektrische Feld quellenfrei sein muss.
 
 %Darf auch weggelassen werden.
 \subsubsection{Exkurs zur Laplace-Gleichung}

--- a/buch/papers/maxwell/magnetostatik.tex
+++ b/buch/papers/maxwell/magnetostatik.tex
@@ -10,7 +10,7 @@
 \rhead{Magnetostatik}
 
 
-Wenn sich eine Ladung mit konstanter Geschwindigkeit bewegt, entsteht um sie herum ein rotationssymmetrisch Magnetfeld. Darüber hinaus wirken auch magnetische Kräfte auf die Ladung.
+Wenn sich eine Ladung mit konstanter Geschwindigkeit bewegt, entsteht um sie herum ein rotationssymmetrisches Magnetfeld. Darüber hinaus wirken auch magnetische Kräfte auf die Ladung.
 Wenn sich viele Ladungen mit einer konstanten Geschwindigkeit durch einen Leiter bewegen, erzeugen diese einen konstanten Strom, welcher ein konstantes magnetisches Feld, also ein Feld, welches sich über die Zeit nicht ändert, zur Folge hat. Dieses wirkt konzentrisch um den Leiter, wie in Abbildung \ref{maxwell:flussdichte} ersichtlich ist. Ausserdem ist in der Abbildung ersichtlich, dass die Feldlinien einen geschlossenen Pfad bilden. Dies zeigt, dass das magnetische Feld keine Quellen aufweist, also quellenfrei ist, und dass es somit keine magnetischen Monopole gibt.
 
 In der Magnetostatik betrachten wir also stationäre magnetische Felder, die Ursache dafür sind Permanentmagnete oder wie bereits erwähnt Gleichströme bzw. Ladungen mit konstanter Geschwindigkeit.
@@ -126,7 +126,7 @@ berechnen. Also das Skalarprodukt der Wirkgrösse und dem Potential des wirkende
 
 \subsection{Amperesches Gesetz}
 Das Ziel dieses Abschnitts ist erneut eine partielle Differentialgleichung zu finden, welche das Wesen des magnetischen Vektorpotentials und somit des magnetischen Feldes beschreibt.
-Wiederum betrachten wir unter den oben vorausgesetzten Bedingungen einen luftleeren, dreidimensionalen Raum $V \subset \mathbb{R}^3$ in welchem das Vektorfeld des magnetischen Vektorpotentials $\vec{A}(x,y,z)$, somit das magnetische Feld $\vec{B}(x,y,,z)$ und eine magnetische Wirkgrösse $q\vec{v}$  existieren. 
+Wiederum betrachten wir unter den oben vorausgesetzten Bedingungen einen luftleeren, dreidimensionalen Raum $V \subset \mathbb{R}^3$ in welchem das Vektorfeld des magnetischen Vektorpotentials $\vec{A}(x,y,z)$, somit das magnetische Feld $\vec{B}(x,y,z)$ und eine magnetische Wirkgrösse $q\vec{v}$  existieren. 
 
 \subsubsection{Ansatz}
 
@@ -137,7 +137,7 @@ Die Energiedichte des magnetischen Feldes mit \eqref{maxwell:definitionVektorpot
 \frac{1}{2\mu_0}\vec{B}(x,y,z)^2
 =
 \frac{1}{2\mu_0}\left(\nabla\times\vec{A}(x,y,z)\right)^2. \]
-Somit berechnet sich die Gesamtenergie jenes zu 
+Die Gesamtenergie jenes berechnet sich dadurch als
 \begin{equation}
 	\label{maxwell:magnetFeldEnergie}
 	W_{\text{m}} = \iiint_V w_m\, dV\,.
@@ -156,7 +156,7 @@ Da unser Ziel jedoch ist, das Integral der Gesamtenergie zu minimieren, müssen 
 Dafür betrachten wir erneut nur ein kleines, ein infinitesimales Stück der Ladung also $dq\,\vec{v}$ und können mithilfe von $dq = \varrho\,dV$, wobei $\varrho$ die Ladungsdichte ist, dieses kleine Stück der Ladung sofort zu $\vec{v}\varrho\,dV$ umschreiben.
 Wenn wir uns jetzt überlegen, dass sich eine Ladungsdichte mit einer Geschwindigkeit $\vec{v}$ bewegt, können wir auch sagen, dass dies äquivalent zu einer Stromdichte $\vec{\jmath}=\varrho\vec{v}$ ist. 
 Die kleinen bzw. infinitesimale Stücke der Wirkgrösse formen wir also zu \[\vec{\jmath}\,dV = \varrho\vec{v}\,dV\]
-um und erhalten mit einer Integration über den ganzen Raum
+um und erhalten mit einer Integration über den ganzen Raum $V$
 \begin{equation}
 	W_{\text{p}}
 	= 
@@ -211,7 +211,7 @@ abgelesen und definiert werden.
 Hierbei wollen wir darauf hinweisen, dass die Lagrange-Funktion in diesem Fall von einem Vektor, dem magnetischen Vektorpotential $\vec{A}$ abhängig ist. 
 Das bedeutet, dass jede Komponente des Vektorpotentials einzeln variiert werden kann, was später die Ursache für mehrere Ausführungen der Euler-Ostrogradski-Differentialgleichung sein wird.
 
-Erneut stellen wir auch fest, dass ein additiver Term dazugekommen ist, wie weiter oben beschrieben handelt es sich auch hier um einem Koppelungsterm, welcher hier jedoch die Wechselwirkung zwischen dem Feld $\vec{A}$ und der Wirkgrösse also der Stromdichte $\vec{\jmath}$ beschreibt.
+Erneut stellen wir auch fest, dass ein additiver Term dazugekommen ist, wie weiter oben beschrieben handelt es sich auch hier um einem Kopplungsterm, welcher hier jedoch die Wechselwirkung zwischen dem Feld $\vec{A}$ und der Wirkgrösse, also der Stromdichte $\vec{\jmath}$ beschreibt.
 
 \subsubsection{Einsetzen in die Euler-Ostrogradski-Differentialgleichung}
 

--- a/buch/papers/maxwell/magnetostatik.tex
+++ b/buch/papers/maxwell/magnetostatik.tex
@@ -124,7 +124,7 @@ berechnen. Also das Skalarprodukt der Wirkgrösse und dem Potential des wirkende
 %Mit dem Vektorpotential können ähnlich wie beim elektrischen Potential, energetische Zustände beschrieben werden. Die Wirkgrösse hier ist allerdings eine bewegte Ladung also eine Ladung $q$, welche eine Geschwindigkeit $\vec{v}$ hat. So kann das magnetische Potential dieser Grösse an einem Punkt berechnet werden. Zusätzlich ergibt sich über das Vektorpotential so auch die potentielle Energie dieser Wirkgrösse, auf welche weiter unten noch spezifischer eingegangen wird.
 
 
-\subsection{Amperesches Gesetz}
+\subsection{Ampèresches Gesetz}
 Das Ziel dieses Abschnitts ist erneut eine partielle Differentialgleichung zu finden, welche das Wesen des magnetischen Vektorpotentials und somit des magnetischen Feldes beschreibt.
 Wiederum betrachten wir unter den oben vorausgesetzten Bedingungen einen luftleeren, dreidimensionalen Raum $V \subset \mathbb{R}^3$ in welchem das Vektorfeld des magnetischen Vektorpotentials $\vec{A}(x,y,z)$, somit das magnetische Feld $\vec{B}(x,y,z)$ und eine magnetische Wirkgrösse $q\vec{v}$  existieren. 
 
@@ -211,7 +211,7 @@ abgelesen und definiert werden.
 Hierbei wollen wir darauf hinweisen, dass die Lagrange-Funktion in diesem Fall von einem Vektor, dem magnetischen Vektorpotential $\vec{A}$ abhängig ist. 
 Das bedeutet, dass jede Komponente des Vektorpotentials einzeln variiert werden kann, was später die Ursache für mehrere Ausführungen der Euler-Ostrogradski-Differentialgleichung sein wird.
 
-Erneut stellen wir auch fest, dass ein additiver Term dazugekommen ist, wie weiter oben beschrieben handelt es sich auch hier um einem Kopplungsterm, welcher hier jedoch die Wechselwirkung zwischen dem Feld $\vec{A}$ und der Wirkgrösse, also der Stromdichte $\vec{\jmath}$ beschreibt.
+Erneut stellen wir auch fest, dass ein additiver Term dazugekommen ist, wie weiter oben beschrieben handelt es sich auch hier um einen Kopplungsterm, welcher hier jedoch die Wechselwirkung zwischen dem Feld $\vec{A}$ und der Wirkgrösse, also der Stromdichte $\vec{\jmath}$ beschreibt.
 
 \subsubsection{Einsetzen in die Euler-Ostrogradski-Differentialgleichung}
 

--- a/buch/papers/maxwell/magnetostatik.tex
+++ b/buch/papers/maxwell/magnetostatik.tex
@@ -10,7 +10,7 @@
 \rhead{Magnetostatik}
 
 
-Wenn sich eine Ladung mit konstanter Geschwindigkeit bewegt, entsteht um sie herum ein konzentrisches Magnetfeld. Darüber hinaus wirken auch magnetische Kräfte auf die Ladung.
+Wenn sich eine Ladung mit konstanter Geschwindigkeit bewegt, entsteht um sie herum ein rotationssymmetrisch Magnetfeld. Darüber hinaus wirken auch magnetische Kräfte auf die Ladung.
 Wenn sich viele Ladungen mit einer konstanten Geschwindigkeit durch einen Leiter bewegen, erzeugen diese einen konstanten Strom, welcher ein konstantes magnetisches Feld, also ein Feld, welches sich über die Zeit nicht ändert, zur Folge hat. Dieses wirkt konzentrisch um den Leiter, wie in Abbildung \ref{maxwell:flussdichte} ersichtlich ist. Ausserdem ist in der Abbildung ersichtlich, dass die Feldlinien einen geschlossenen Pfad bilden. Dies zeigt, dass das magnetische Feld keine Quellen aufweist, also quellenfrei ist, und dass es somit keine magnetischen Monopole gibt.
 
 In der Magnetostatik betrachten wir also stationäre magnetische Felder, die Ursache dafür sind Permanentmagnete oder wie bereits erwähnt Gleichströme bzw. Ladungen mit konstanter Geschwindigkeit.
@@ -80,7 +80,7 @@ also das elektrische Potential im gesamten Raum als null angenommen.
 Wie auch in der Elektrostatik, gibt es in der Magnetostatik ein Potential, mit welchem energetische Zustände berechnet und ausgedrückt werden können. Im Unterschied ist jedoch das magnetische Potential ebenfalls eine vektorielle Grösse, also auch ein Vektorfeld. Das magnetische Vektorpotential zeigt jeweils in die selbe Richtung wie der Geschwindigkeitsvektor der bewegten Ladung.
 Durch das magnetische Vektorpotential, kann die magnetische Flussdichte als 
 \begin{equation}
-	\text{rot}\vec{A}=\nabla \times \vec{A}
+	\operatorname{rot}\vec{A}=\nabla \times \vec{A}
 	=
 	\vec{B}
 	\label{maxwell:definitionVektorpot}
@@ -131,7 +131,7 @@ Wiederum betrachten wir unter den oben vorausgesetzten Bedingungen einen luftlee
 \subsubsection{Ansatz}
 
 Wieder soll die Energie des gesamten Systems zusammengetragen und minimiert werden. 
-Die Energiedichte des magnetischen Feldes mit \ref{maxwell:definitionVektorpot} eingesetzt ist
+Die Energiedichte des magnetischen Feldes mit \eqref{maxwell:definitionVektorpot} eingesetzt ist
 \[ w_{\text{m}} 
 = 
 \frac{1}{2\mu_0}\vec{B}(x,y,z)^2
@@ -151,7 +151,7 @@ q\vec{v}
 \vec{A}
  \]
 berechnen lässt.
-Da unser Ziel jedoch ist, das Integral der Gesamtenergie zu minimieren, müssen wir auch diese potentielle Energie über den gesamten Raum bzw. das selbe Volumen integrieren wie das Integral in \ref{maxwell:magnetFeldEnergie}. 
+Da unser Ziel jedoch ist, das Integral der Gesamtenergie zu minimieren, müssen wir auch diese potentielle Energie über den gesamten Raum bzw. das selbe Volumen integrieren wie das Integral in \eqref{maxwell:magnetFeldEnergie}. 
 
 Dafür betrachten wir erneut nur ein kleines, ein infinitesimales Stück der Ladung also $dq\,\vec{v}$ und können mithilfe von $dq = \varrho\,dV$, wobei $\varrho$ die Ladungsdichte ist, dieses kleine Stück der Ladung sofort zu $\vec{v}\varrho\,dV$ umschreiben.
 Wenn wir uns jetzt überlegen, dass sich eine Ladungsdichte mit einer Geschwindigkeit $\vec{v}$ bewegt, können wir auch sagen, dass dies äquivalent zu einer Stromdichte $\vec{\jmath}=\varrho\vec{v}$ ist. 
@@ -211,7 +211,7 @@ abgelesen und definiert werden.
 Hierbei wollen wir darauf hinweisen, dass die Lagrange-Funktion in diesem Fall von einem Vektor, dem magnetischen Vektorpotential $\vec{A}$ abhängig ist. 
 Das bedeutet, dass jede Komponente des Vektorpotentials einzeln variiert werden kann, was später die Ursache für mehrere Ausführungen der Euler-Ostrogradski-Differentialgleichung sein wird.
 
-Erneut stellen wir auch fest, dass ein additiver Term dazugekommen ist, wie weiter oben beschrieben handelt es sich auch hier um einem Koppelungsterm, welcher hier jedoch die Wechselwirkung zwischen dem Feld und der Wirkgrösse also der Stromdichte $\vec{\jmath}$ beschreibt.
+Erneut stellen wir auch fest, dass ein additiver Term dazugekommen ist, wie weiter oben beschrieben handelt es sich auch hier um einem Koppelungsterm, welcher hier jedoch die Wechselwirkung zwischen dem Feld $\vec{A}$ und der Wirkgrösse also der Stromdichte $\vec{\jmath}$ beschreibt.
 
 \subsubsection{Einsetzen in die Euler-Ostrogradski-Differentialgleichung}
 
@@ -262,7 +262,7 @@ Da jede Komponente des magnetischen Vektorpotentials für sich variiert werden k
 	- \frac{\partial}{\partial y}(A_{3,y}-A_{2,z})
 \end{equation}
 Wobei für $i=2,3$ genau das gleiche Vorgehen wie bei $i=1$ angewendet wurde.
-Mithilfe von \ref{maxwell:nablaA} wollen wir jetzt den Ausdruck $\nabla\times\nabla\times\vec{A} = \nabla\times\vec{B}$ betrachten.
+Mithilfe von \eqref{maxwell:nablaA} wollen wir jetzt den Ausdruck $\nabla\times\nabla\times\vec{A} = \nabla\times\vec{B}$ betrachten.
 
 \begin{equation}
 	\renewcommand{\arraystretch}{1.9}
@@ -293,7 +293,7 @@ Mithilfe von \ref{maxwell:nablaA} wollen wir jetzt den Ausdruck $\nabla\times\na
 		\frac{\partial}{\partial x}(A_{1,z}-A_{3,x}) - \frac{\partial}{\partial y}(A_{3,y}-A_{2,z})
 	\end{pmatrix}
 \end{equation}
-Wir stellen fest, dass die drei Komponenten des resultierenden Vektors genau mit den rechten Seiten der drei Gleichungen \ref{maxwell:magnetoL1}, \ref{maxwell:magnetoL2} und \ref{maxwell:magnetoL3} übereinstimmen.
+Wir stellen fest, dass die drei Komponenten des resultierenden Vektors genau mit den rechten Seiten der drei Gleichungen \eqref{maxwell:magnetoL1}, \eqref{maxwell:magnetoL2} und \eqref{maxwell:magnetoL3} übereinstimmen.
 Dank der kompakten vektoriellen Schreibweise, können wir also unser Ergebnis der genannten drei Gleichungen zu
 \[ 
 \mu_0\vec{\jmath} 
@@ -304,6 +304,6 @@ zusammenfassen. Hierbei resultiert das Ampèresche-Gesetz.
 
 \subsubsection{Interpretation}
 
-Mittels der Variationsrechnung konnten wir das Ampèresche-Gesetz herleiten, welches besagt, dass die Stromdichte proportional zur Rotation des magnetischen Feldes ist. Anders ausgedrückt kann man, dass die Stromdichte, welche durch eine Fläche strömt, proportional zum magnetischen Feld ist, welches um den Rand dieser selben Fläche wirkt.
+Mittels der Variationsrechnung konnten wir das Ampèresche-Gesetz herleiten, welches besagt, dass die Stromdichte proportional zur Rotation des magnetischen Feldes ist. Anders ausgedrückt kann man sagen, dass die Stromdichte, welche durch eine Fläche strömt, proportional zum magnetischen Feld ist, welches um den Rand dieser selben Fläche wirkt.
 
 

--- a/buch/papers/maxwell/main.tex
+++ b/buch/papers/maxwell/main.tex
@@ -7,14 +7,15 @@
 % !TEX encoding = UTF-8
 %
 
-\chapter{Maxwell\label{chapter:maxwell}}
+\chapter{Maxwell-Gleichungen als Variationsprinzip\label{chapter:maxwell}}
 \kopflinks{Maxwell-Gleichungen als Variationsprinzip}
 \begin{refsection}
 \chapterauthor{Maurin Doswald und Stephan Oseghale}
 
 Als James Clerk Maxwell 1865 seine Arbeit über das elektromagnetische Feld veröffentlichte, gelang es ihm, das Wesen des elektrischen- und magnetischen Feldes, sowie die Interaktion derselben mathematisch zu beschreiben und somit das Grundwesen der Elektrodynamik aufzuzeigen.
 Durch seine theoretische Arbeit konnte experimentell die Existenz von elektromagnetischen Wellen und ihre Ausbreitung mit Lichtgeschwindigkeit nachgewiesen werden.
-Dies führte zu Technologien wie Radio, Radar, Fernsehen und viele weitere Anwendungen in der drahtlosen Kommunikation.
+Dies führte zu Technologien wie Radio, Radar, Fernsehen und viele weitere Anwendungen in der drahtlosen Kommunikation. 
+Eine detaillierte Untersuchung einer weiteren Anwendung wird im Kapitel \ref{chapter:antennen} über Antennen behandelt.
 
 Die Grundidee zur Formulierung dieser Gleichungen kam durch eine Reihe von experimentellen Beobachtungen und theoretischen Ansätzen unterschiedlichster Wissenschaftler unter anderem Michael Faraday und André-Marie Ampère.
 Durch mathematische Analysen und Experimente entwickelte Maxwell schlussendlich 20 Gleichungen, welche später von Oliver Heavyside und Willard Gibbs in die heutige bekannte vektorielle Schreibweise von vier Gleichungen gebracht wurden.
@@ -25,6 +26,7 @@ Das Ziel dieser Arbeit ist aufzuzeigen, dass die vier fundamentalen Gleichungen 
 \input{papers/maxwell/elektrostatik_mit_quelle.tex}
 \input{papers/maxwell/magnetostatik.tex}
 \input{papers/maxwell/elektrodynamik.tex}
+\input{papers/maxwell/schluss.tex}
 %\input{papers/maxwell/teil0.tex}
 %\input{papers/maxwell/teil1.tex}
 %\input{papers/maxwell/teil2.tex}

--- a/buch/papers/maxwell/main.tex
+++ b/buch/papers/maxwell/main.tex
@@ -14,8 +14,8 @@
 
 Als James Clerk Maxwell 1865 seine Arbeit über das elektromagnetische Feld veröffentlichte, gelang es ihm, das Wesen des elektrischen- und magnetischen Feldes, sowie die Interaktion derselben mathematisch zu beschreiben und somit das Grundwesen der Elektrodynamik aufzuzeigen.
 Durch seine theoretische Arbeit konnte experimentell die Existenz von elektromagnetischen Wellen und ihre Ausbreitung mit Lichtgeschwindigkeit nachgewiesen werden.
-Dies führte zu Technologien wie Radio, Radar, Fernsehen und viele weitere Anwendungen in der drahtlosen Kommunikation. 
-Eine detaillierte Untersuchung einer weiteren Anwendung wird im Kapitel \ref{chapter:antennen} über Antennen behandelt.
+Dies führte zu Technologien wie Radio, Radar, Fernsehen, Antennen (Kapitel \ref{chapter:antennen}) und viele weitere Anwendungen in der drahtlosen Kommunikation. 
+%Eine detaillierte Untersuchung einer weiteren Anwendung wird im Kapitel \ref{chapter:antennen} über Antennen behandelt.
 
 Die Grundidee zur Formulierung dieser Gleichungen kam durch eine Reihe von experimentellen Beobachtungen und theoretischen Ansätzen unterschiedlichster Wissenschaftler unter anderem Michael Faraday und André-Marie Ampère.
 Durch mathematische Analysen und Experimente entwickelte Maxwell schlussendlich 20 Gleichungen, welche später von Oliver Heavyside und Willard Gibbs in die heutige bekannte vektorielle Schreibweise von vier Gleichungen gebracht wurden.

--- a/buch/papers/maxwell/mathFormulierung.tex
+++ b/buch/papers/maxwell/mathFormulierung.tex
@@ -44,16 +44,16 @@ In Abbildung \ref{maxwell:skalarGrad} ist ein Vektorfeld abgebildet.
 
 \subsubsection{Gradient}
 
-Der Gradient einer Funktion $f(x)$ ist als 
+Der Gradient einer Funktion $f:\mathbb{R}^3 \rightarrow \mathbb{R}$ ist als 
 \[
 \renewcommand{\arraystretch}{1.9} 
-\operatorname{grad}f(x) = \nabla f(x) = \begin{pmatrix}
+\operatorname{grad}f = \nabla f = \begin{pmatrix}
 \displaystyle
-\frac{\partial f(x)}{\partial x} \\
+\frac{\partial f}{\partial x} \\
 \displaystyle
-\frac{\partial f(x)}{\partial y} \\
+\frac{\partial f}{\partial y} \\
 \displaystyle
-\frac{\partial f(x)}{\partial z} \\
+\frac{\partial f}{\partial z} \\
 \end{pmatrix}\] 
 definiert und wurde bereits in Abschnitt \ref{buch:fuvar:richtungsableitung:def:gradient} genauer behandelt. Dieser Operator wird auf ein Skalarfeld angewendet und resultiert in einem Vektorfeld. 
 Die Richtung der Vektoren dieses neuen Vektorfeldes zeigen immer in die Richtung der grössten bzw. steilsten Zunahme, wobei der Betrag die Steilheit des Anstiegs repräsentiert.
@@ -61,7 +61,7 @@ Die Richtung der Vektoren dieses neuen Vektorfeldes zeigen immer in die Richtung
 
 \subsubsection{Divergenz}
 %TODO: Link auf Kapitel von Müller
-Die Divergenz eines Vektorfeldes $\vec{F}$ ist definiert als 
+Die Divergenz eines Vektorfeldes $\vec{F}:\mathbb{R}^3 \rightarrow \mathbb{R}^3$ ist definiert als 
 \[ \operatorname{div}\vec{F} = \nabla\cdot\vec{F} 
 = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}. \]
 Angewendet wird sie auf ein Vektorfeld und resultiert in ein Skalarfeld.
@@ -71,7 +71,7 @@ Ein Vektorfeld wird als quellenfrei bezeichnet, wenn seine Divergenz gleich null
 
 \subsubsection{Rotation}
 %TODO: Link auf Kapitel von Müller
-Die Rotation eines Vektorfeldes $\vec{F}$ ist definiert als
+Die Rotation eines Vektorfeldes $\vec{F}:\mathbb{R}^3 \rightarrow \mathbb{R}^3$ ist definiert als
 \[
 \renewcommand{\arraystretch}{1.9} 
 \operatorname{rot}\vec{F} = 

--- a/buch/papers/maxwell/mathFormulierung.tex
+++ b/buch/papers/maxwell/mathFormulierung.tex
@@ -16,7 +16,7 @@ Da sowohl das elektrische Feld $\vec{E}$ wie auch das magnetische Feld bzw. die 
 Ein Skalarfeld ist eine Funktion der Form
 \( f:\mathbb{R}^n \rightarrow \mathbb{R}, \) 
 die jedem Punkt im Raum ein Skalar zuordnet.
-Alltägliches Beispiele für ein Skalarfelder sind Temperaturverteilungen, Ladungsdichten oder Potentiale. In Abbildung \ref{maxwell:skalarGrad} ist das Skalarfeld einer positiven Ladung abgebildet.
+Alltägliches Beispiele für ein Skalarfelder sind Temperaturverteilungen, Ladungsdichten oder Potentiale. In Abbildung \ref{maxwell:skalarGrad} ist ein Skalarfeld abgebildet.
 
 
 %Zu den wichtigsten Operationen eines Skalarfeldes gehört der Gradient, welcher dem Skalar- ein Vektorfeld zuordnet.

--- a/buch/papers/maxwell/mathFormulierung.tex
+++ b/buch/papers/maxwell/mathFormulierung.tex
@@ -44,27 +44,38 @@ In Abbildung \ref{maxwell:skalarGrad} ist ein Vektorfeld abgebildet.
 
 \subsubsection{Gradient}
 
-Der Gradient wurde bereits in Abschnitt \ref{buch:fuvar:richtungsableitung:def:gradient} definiert. Dieser Operator, welcher auf ein Skalarfeld angewendet wird, resultiert in einem Vektorfeld. 
-Die Richtung der Vektoren dieses neuen Vektorfeldes zeigen demnach immer in die Richtung der grössten bzw. steilsten Zunahme.
+Der Gradient einer Funktion $f(x)$ ist als 
+\[
+\renewcommand{\arraystretch}{1.9} 
+\operatorname{grad}f(x) = \nabla f(x) = \begin{pmatrix}
+\displaystyle
+\frac{\partial f(x)}{\partial x} \\
+\displaystyle
+\frac{\partial f(x)}{\partial y} \\
+\displaystyle
+\frac{\partial f(x)}{\partial z} \\
+\end{pmatrix}\] 
+definiert und wurde bereits in Abschnitt \ref{buch:fuvar:richtungsableitung:def:gradient} genauer behandelt. Dieser Operator wird auf ein Skalarfeld angewendet und resultiert in einem Vektorfeld. 
+Die Richtung der Vektoren dieses neuen Vektorfeldes zeigen immer in die Richtung der grössten bzw. steilsten Zunahme, wobei der Betrag die Steilheit des Anstiegs repräsentiert.
 %Weiter unten wird ersichtlich, dass auch das elektrische Feld ein Gradientenfeld ist \[ \vec{E} = -\nabla\varphi, \] wobei $\varphi$ das elektrische Potential ist.
 
 \subsubsection{Divergenz}
 %TODO: Link auf Kapitel von Müller
 Die Divergenz eines Vektorfeldes $\vec{F}$ ist definiert als 
-\[ \text{div}\vec{F} = \nabla\cdot\vec{F} 
+\[ \operatorname{div}\vec{F} = \nabla\cdot\vec{F} 
 = \frac{\partial F_x}{\partial x} + \frac{\partial F_y}{\partial y} + \frac{\partial F_z}{\partial z}. \]
 Angewendet wird sie auf ein Vektorfeld und resultiert in ein Skalarfeld.
 Die Divergenz sagt aus, ob an einem Punkt mehr ``hinein-'' als ``herausfliesst'' und macht so eine Aussage über das Bestehen von Quellen und Senken. 
 Wenn die Divergenz negativ ist, liegt eine Senke vor, wenn sie positiv ist eine Quelle.
-Ein Vektorfeld wird quellenfrei genannt, wenn seine Divergenz zu null resultiert.
+Ein Vektorfeld wird als quellenfrei bezeichnet, wenn seine Divergenz gleich null ist.
 
 \subsubsection{Rotation}
 %TODO: Link auf Kapitel von Müller
 Die Rotation eines Vektorfeldes $\vec{F}$ ist definiert als
 \[
 \renewcommand{\arraystretch}{1.9} 
-\text{rot}\vec{F} = 
-\text{curl}\vec{F}
+\operatorname{rot}\vec{F} = 
+\operatorname{curl}\vec{F}
 =\nabla\times\vec{F}
 = \begin{pmatrix}
 	\displaystyle
@@ -76,4 +87,4 @@ Die Rotation eines Vektorfeldes $\vec{F}$ ist definiert als
 \end{pmatrix}
 . \]
 Mit dieser Operation wird einem Vektorfeld ein neues Vektorfeld zugeordnet, welches eine Aussage darüber macht, wie stark das Feld sich um einen Punkt dreht bzw. rotiert.
-Wenn die Rotation zu null resultiert, ist das Feld wirbelfrei.
+Ein Vektorfeld ist wirbelfrei, wenn seine Rotation null ist.

--- a/buch/papers/maxwell/references.bib
+++ b/buch/papers/maxwell/references.bib
@@ -33,10 +33,24 @@
         url = {https://doi.org/10.1016/j.acha.2017.11.004}
 }
 
+@article{maxwell:yu,
+		author = { Thomas Yu },
+		title = {Lagrangian formulation of the electromagnetic field}
+}
+
+
+@article{maxwell:bardi,
+		author = {Istvan Bardi},
+		title = {The least action and the variational Calculus in electrodynamics},
+		year = 1979
+}
+
 @book{maxwell:hdlang,
 	author = { Hans-Dieter Lang},
 	title = { Elektrotechnik 2 }
 }
+
+
 
 
 

--- a/buch/papers/maxwell/schluss.tex
+++ b/buch/papers/maxwell/schluss.tex
@@ -1,0 +1,16 @@
+%
+% einleitung.tex -- Beispiel-File für die Einleitung
+%
+% (c) 2020 Prof Dr Andreas Müller, Hochschule Rapperswil
+%
+% !TEX root = ../../buch.tex
+% !TEX encoding = UTF-8
+%
+%Konklusion
+\section{Konklusion}
+
+In dieser Arbeit haben wir die Maxwell-Gleichungen im Kontext der Variationsrechnung untersucht und gezeigt, dass diese als Ergebnis der Minimierung einer geeigneten Lagrange-Funktion resultieren. Wir haben die Energien eines Systems zusammengetragen und dieses Funktional mittels der Variationsrechnung minimiert.
+In dieser Untersuchung konnte einmal mehr verdeutlicht werden, wie fundamentale physikalische Gesetze aus extremal Prinzipien folgen. 
+Insbesondere konnten wir zeigen, dass gerade auch die fundamentalen Gleichungen der Elektrodynamik, die Maxwell-Gleichungen, aus einem Variationsprinzip hergeleitet werden können. Dieses Resultat unterstreicht jene physikalische Theorie erneut. 
+
+Des Weiteren könnte diese Arbeit als Ausgangspunkt genommen werden, um weitere Felder und ihre Wechselwirkungen zu berücksichtigen und in die Lagrange-Funktion miteinzubeziehen. Durch eine Erweiterung würde man erwarten, dass andere fundamentale Gesetze resultieren, die bis hin zur Lagrange-Funktion des gegenwärtig umfassendsten Modell der Physik, dem Standardmodell reichen.

--- a/buch/papers/maxwell/schluss.tex
+++ b/buch/papers/maxwell/schluss.tex
@@ -10,7 +10,7 @@
 \section{Konklusion}
 
 In dieser Arbeit haben wir die Maxwell-Gleichungen im Kontext der Variationsrechnung untersucht und gezeigt, dass diese als Ergebnis der Minimierung einer geeigneten Lagrange-Funktion resultieren. Wir haben die Energien eines Systems zusammengetragen und dieses Funktional mittels der Variationsrechnung minimiert.
-In dieser Untersuchung konnte einmal mehr verdeutlicht werden, wie fundamentale physikalische Gesetze aus extremal Prinzipien folgen. 
+Diese Untersuchung verdeutlicht einmal mehr, wie grundlegende physikalische Gesetze aus extremal Prinzipien folgen. 
 Insbesondere konnten wir zeigen, dass gerade auch die fundamentalen Gleichungen der Elektrodynamik, die Maxwell-Gleichungen, aus einem Variationsprinzip hergeleitet werden können. Dieses Resultat unterstreicht jene physikalische Theorie erneut. 
 
-Des Weiteren könnte diese Arbeit als Ausgangspunkt genommen werden, um weitere Felder und ihre Wechselwirkungen zu berücksichtigen und in die Lagrange-Funktion miteinzubeziehen. Durch eine Erweiterung würde man erwarten, dass andere fundamentale Gesetze resultieren, die bis hin zur Lagrange-Funktion des gegenwärtig umfassendsten Modell der Physik, dem Standardmodell reichen.
+Des weiteren könnte diese Arbeit als Ausgangspunkt genommen werden, um weitere Felder und ihre Wechselwirkungen zu berücksichtigen und in die Lagrange-Funktion miteinzubeziehen. Durch eine Erweiterung würde man erwarten, dass andere fundamentale Gesetze resultieren, die bis hin zur Lagrange-Funktion des gegenwärtig umfassendsten Modell der Physik, dem Standardmodell reichen.

--- a/buch/papers/maxwell/schluss.tex
+++ b/buch/papers/maxwell/schluss.tex
@@ -8,7 +8,7 @@
 %
 %Konklusion
 \section{Konklusion}
-
+\rhead{Konklusion}
 In dieser Arbeit haben wir die Maxwell-Gleichungen im Kontext der Variationsrechnung untersucht und gezeigt, dass diese als Ergebnis der Minimierung einer geeigneten Lagrange-Funktion resultieren. Wir haben die Energien eines Systems zusammengetragen und dieses Funktional mittels der Variationsrechnung minimiert.
 Diese Untersuchung verdeutlicht einmal mehr, wie grundlegende physikalische Gesetze aus extremal Prinzipien folgen. 
 Insbesondere konnten wir zeigen, dass gerade auch die fundamentalen Gleichungen der Elektrodynamik, die Maxwell-Gleichungen, aus einem Variationsprinzip hergeleitet werden können. Dieses Resultat unterstreicht jene physikalische Theorie erneut. 


### PR DESCRIPTION
Guten Tag Herr Müller

Hier ein nächster Pull Request.

Noch zwei Fragen:
1. Wir würden gerne auf Ihre Definition 4.8 Referenzieren. Könnten SIe dort noch ein Label erstellen?

2. Im Abschnitt 15.4.1 Dynamische Maxwell Gleichungen sprechen wir von einer statischen Ladungsdichte. Wir wollen damit sagen, dass sich die Ladungsdichte nicht bewegt, demnach sich nicht über die Zeit verändert, folglich zeitunabhängig ist. Ist das korrekt, dass wir dann schreiben, dass $\rho$ nur eine Funktion von x,y,z ist und nicht wie zbsp. die Felder von t,x,y,z abhängig sind? Also sagen wir das korrekt aus, indem wir $\rho(x,y,z)$ statt $\rho(t,x,y,z)$ schreiben?

Vielen Dank und beste Grüsse
Maurin Doswald